### PR TITLE
Add prettier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx pretty-quick --staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.husky/
+node_modules/
+packages/**/dist/*

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,8 +1,8 @@
 module.exports = {
-  stories: ["../packages/**/__stories__/*.stories.js"],
-  addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
-  framework: "@storybook/react",
+  stories: ['../packages/**/__stories__/*.stories.js'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  framework: '@storybook/react',
   core: {
-    builder: "webpack5",
+    builder: 'webpack5',
   },
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -6,4 +6,4 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,5 @@
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: {argTypesRegex: '^on[A-Z].*'},
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Run `npm run storybook` from the root directory to start storybook locally.
 - [storybook](https://storybook.js.org/docs/react/get-started/introduction) for documenting components.
 - [commitlint](https://commitlint.js.org) enforces commit linting. Currently set up to enforce the [Conventional Commits](https://www.conventionalcommits.org) specification.
 - [husky](https://typicode.github.io/husky) for git hooks.
+- [prettier](https://prettier.io) for code formatting. It's best to [configure your editor](https://prettier.io/docs/en/editors.html) to run prettier on save, but it will also auto-format before committing.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["@commitlint/config-conventional"],
+  extends: ['@commitlint/config-conventional'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16382,6 +16382,12 @@
         }
       }
     },
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -17814,6 +17820,83 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
+    },
+    "pretty-quick": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.1.3.tgz",
+      "integrity": "sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "execa": "^4.0.0",
+        "find-up": "^4.1.0",
+        "ignore": "^5.1.4",
+        "mri": "^1.1.5",
+        "multimatch": "^4.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+          "dev": true
+        },
+        "multimatch": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+          "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "array-differ": "^3.0.0",
+            "array-union": "^2.1.0",
+            "arrify": "^2.0.1",
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
     },
     "prismjs": {
       "version": "1.26.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-loader": "^8.2.3",
     "husky": "^7.0.4",
     "lerna": "^4.0.0",
+    "prettier": "2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "webpack": "^5.66.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "husky": "^7.0.4",
     "lerna": "^4.0.0",
     "prettier": "2.5.1",
+    "pretty-quick": "^3.1.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "webpack": "^5.66.0",

--- a/packages/link/__stories__/Link.stories.js
+++ b/packages/link/__stories__/Link.stories.js
@@ -1,14 +1,14 @@
-import React from "react";
-import Link from "../src/Link";
+import React from 'react';
+import Link from '../src/Link';
 
 export default {
-  title: "Link",
+  title: 'Link',
 };
 
 const Template = (args) => <Link {...args} />;
 
 export const Primary = Template.bind({});
 Primary.args = {
-  href: "/some/url",
-  text: "click me!",
+  href: '/some/url',
+  text: 'click me!',
 };

--- a/packages/link/src/Link.jsx
+++ b/packages/link/src/Link.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 // TODO: add prop-types
 
 export default function Link(props) {

--- a/packages/link/src/index.js
+++ b/packages/link/src/index.js
@@ -1,1 +1,1 @@
-export { default as Link } from "./Link";
+export {default as Link} from './Link';

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,1 +1,4 @@
-module.exports = {};
+module.exports = {
+  singleQuote: true,
+  bracketSpacing: false,
+};


### PR DESCRIPTION
Sets up prettier for consistent code formatting. Currently, it's set to auto-format any files about to be committed during pre-commit using [pretty-quick and husky](https://prettier.io/docs/en/precommit.html#option-2-pretty-quickhttpsgithubcomazzpretty-quick).

For now, the options we use in code-dot-org seemed fine, but [these are all the options](https://prettier.io/docs/en/options.html) if there are any others folks think I should add.