### PR TITLE
Add and configure eslint-import-resolver-webpack

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,10 +22,6 @@ module.exports = {
     'default-case': 'error',
     'dot-notation': 'error',
     eqeqeq: 'error',
-    // TODO: Turn import/no-unresolved back on once webpack is configured.
-    // See https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-unresolved.md
-    // and https://github.com/import-js/eslint-plugin-import/blob/main/README.md#resolvers for details.
-    'import/no-unresolved': 'off',
     'import/order': 'error',
     'no-duplicate-imports': 'error',
     'no-implicit-globals': 'error',
@@ -84,6 +80,9 @@ module.exports = {
     yoda: 'error',
   },
   settings: {
+    'import/resolver': {
+      webpack: {config: './webpack.config.js'},
+    },
     react: {version: 'detect'},
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9646,6 +9646,12 @@
       "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
       "dev": true
     },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -13021,6 +13027,71 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        }
+      }
+    },
+    "eslint-import-resolver-webpack": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.2.tgz",
+      "integrity": "sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0",
+        "debug": "^3.2.7",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "has": "^1.0.3",
+        "interpret": "^1.4.0",
+        "is-core-module": "^2.7.0",
+        "is-regex": "^1.1.4",
+        "lodash": "^4.17.21",
+        "resolve": "^1.20.0",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.2.0",
+            "tapable": "^0.1.8"
+          }
+        },
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        },
+        "memory-fs": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+          "integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+          "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@storybook/react": "^6.4.12",
     "babel-loader": "^8.2.3",
     "eslint": "^8.6.0",
+    "eslint-import-resolver-webpack": "^0.13.2",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",


### PR DESCRIPTION
[DSCO-35](https://codedotorg.atlassian.net/browse/DSCO-35)
Follow-up to #5 (specifically, [this comment](https://github.com/code-dot-org/dsco_/pull/5#discussion_r788114127)).

Using [eslint-import-resolver-webpack](https://www.npmjs.com/package/eslint-import-resolver-webpack) allows eslint to recognize modules from relative file imports.