### PR TITLE
Initial publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This repository translates our design system to code and publishes the correspon
 
 Run `npm run storybook` from the root directory to start storybook locally.
 
+## Publishing
+
+Run `npm run publish` from the root directory to autogenerate changelogs and publish all packages that have changed since the last release. You'll be asked to confirm before anything is actually published to NPM.
+
+**Tips:**
+
+- Our publish script uses [`lerna publish`](https://github.com/lerna/lerna/tree/main/commands/publish#readme).
+- We use `--conventional-commits`, so Lerna will automatically detect what versions should be published based on commit messages.
+
 ## Creating a New Component
 
 Creating a new component may or may not involve creating a new package for that component. For example, if `@dsco_/form` exists and you're creating a component that belongs in a form, you should add that component to the existing package (don't forget to add tests and stories!).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Run `npm run storybook` from the root directory to start storybook locally.
 
 ## Publishing
 
-Run `npm run publish` from the root directory to autogenerate changelogs and publish all packages that have changed since the last release. You'll be asked to confirm before anything is actually published to NPM.
+1. Make sure you are a member of the `@dsco_` NPM organization and logged in to that NPM account from the command line (`npm whoami` will tell you your username).
+2. Run `npm run publish` from the root directory to autogenerate changelogs and publish all packages that have changed since the last release. You'll be asked to confirm before anything is actually published to NPM.
 
 **Tips:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1736,7 +1736,7 @@
     "@dsco_/link": {
       "version": "file:packages/link",
       "requires": {
-        "@dsco_/common": "^1.0.0",
+        "@dsco_/common": "^0.0.1",
         "prop-types": "^15.8.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build:prod": "NODE_ENV=production lerna run build",
     "build-storybook": "build-storybook",
     "postinstall": "husky install",
+    "preversion": "npm run build:prod",
+    "publish": "lerna publish --conventional-commits",
     "storybook": "start-storybook -p 6006"
   },
   "devDependencies": {

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.0.2 (2022-02-01)
+
+**Note:** Version bump only for package @dsco\_/common

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsco_/common",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Common styles and utilities for DSCO consumers",
   "author": "Madelyn Kasula <maddie.kasula@code.org>",
   "homepage": "https://github.com/code-dot-org/dsco_/tree/main/packages/common#readme",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsco_/common",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Common styles and utilities for DSCO consumers",
   "author": "Madelyn Kasula <maddie.kasula@code.org>",
   "homepage": "https://github.com/code-dot-org/dsco_/tree/main/packages/common#readme",

--- a/packages/link/CHANGELOG.md
+++ b/packages/link/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# 0.1.0 (2022-02-01)
+
+### Features
+
+- **link:** add prop-types and fix eslint errors ([b1399c8](https://github.com/code-dot-org/dsco_/commit/b1399c8fd92ebdb13d0eb971dd43f12701dfaf8d))
+- **link:** add skeleton for Link component ([e8f2a0a](https://github.com/code-dot-org/dsco_/commit/e8f2a0ac2cee398a437cfa6ab72ae973dabafd13))
+- **link:** update default to named export for package ([37a9e99](https://github.com/code-dot-org/dsco_/commit/37a9e99f173412d96aa36a27af98973d395b2949))

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/code-dot-org/dsco_/issues"
   },
   "dependencies": {
-    "@dsco_/common": "^1.0.0",
+    "@dsco_/common": "^0.0.1",
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsco_/link",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "Link component",
   "author": "Madelyn Kasula <maddie.kasula@code.org>",
   "homepage": "https://github.com/code-dot-org/dsco_/tree/main/packages/link#readme",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsco_/link",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Link component",
   "author": "Madelyn Kasula <maddie.kasula@code.org>",
   "homepage": "https://github.com/code-dot-org/dsco_/tree/main/packages/link#readme",
@@ -28,7 +28,7 @@
     "url": "https://github.com/code-dot-org/dsco_/issues"
   },
   "dependencies": {
-    "@dsco_/common": "^0.0.1",
+    "@dsco_/common": "^0.0.2",
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Ran the new `npm run publish` command, which does the following:
- executes the "preversion" script
- runs `lerna publish`
- autogenerates changelogs and commits/pushes "chore(release): publish"