### PR TITLE
feat(link): add underline prop to Link component

### DIFF
--- a/packages/link/__stories__/Link.stories.js
+++ b/packages/link/__stories__/Link.stories.js
@@ -11,4 +11,5 @@ export const Primary = Template.bind({});
 Primary.args = {
   href: '/some/url',
   text: 'click me!',
+  underline: true,
 };

--- a/packages/link/__tests__/Link.test.js
+++ b/packages/link/__tests__/Link.test.js
@@ -3,5 +3,5 @@ import {render} from '@testing-library/react';
 import Link from '../lib/Link';
 
 test('renders', () => {
-  render(<Link text="hi" href="/some/url" />);
+  render(<Link text="hi" href="/some/url" underline/>);
 });

--- a/packages/link/lib/Link.jsx
+++ b/packages/link/lib/Link.jsx
@@ -4,7 +4,7 @@ import * as styles from './link.module.scss';
 
 export default function Link(props) {
   return (
-    <a href={props.href} className={styles.link}>
+    <a href={props.href} className={`${styles.link} ${props.underline ? 'text-underline' : ''}`}>
       {props.text}
     </a>
   );
@@ -15,4 +15,5 @@ Link.displayName = 'Link';
 Link.propTypes = {
   href: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
+  underline: PropTypes.bool,
 };

--- a/packages/link/lib/link.module.scss
+++ b/packages/link/lib/link.module.scss
@@ -5,4 +5,9 @@
   @extend .dsco-text;
 
   color: tokens.$dsco-link-color;
+  text-decoration: none;
+}
+
+.link-underline {
+  text-decoration: underline !important;
 }


### PR DESCRIPTION
Certain links on Code.org, such as that of the footer, aren't underlined. This PR adds the underline prop to underline the text while removing the text decoration of links without such an attribute by default.

Usage can be seen in the unit test for the Link component. The prop is implemented by checking if the underline prop is true and if so, applies a class name known as ".underline" defined in the SCSS. The implementation of this prop is not the cleanest approach to such a problem, but works.