### PR TITLE
Unit test link components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,6 @@ module.exports = {
     'import/order': 'error',
     'no-duplicate-imports': 'error',
     'no-implicit-globals': 'error',
-    'no-magic-numbers': 'error',
     'no-negated-condition': 'error',
     'no-nested-ternary': 'error',
     'no-unneeded-ternary': 'error',

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "publish": "lerna publish --conventional-commits",
     "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook --output-dir ./docs",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",

--- a/packages/link/__tests__/Link.test.js
+++ b/packages/link/__tests__/Link.test.js
@@ -1,7 +1,73 @@
 import React from 'react';
-import {render} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import Link from '../lib/Link';
 
-test('renders', () => {
-  render(<Link text="hi" href="/some/url" />);
+test('can render with text children', () => {
+  render(<Link href="/">homepage</Link>);
+
+  screen.getByRole('link', {name: 'homepage'});
+});
+
+test('can render with element children', () => {
+  render(
+    <Link href="http://www.example.com">
+      <img src="cat.jpg" aria-label="cat" />
+    </Link>
+  );
+
+  screen.getByRole('link');
+  screen.getByRole('img', {name: 'cat'});
+});
+
+test('weight adds corresponding class', () => {
+  render(
+    <Link href="/" weight="medium">
+      homepage
+    </Link>
+  );
+
+  expect(screen.getByRole('link').className).toEqual('link medium');
+});
+
+test('className class is applied last', () => {
+  render(
+    <Link href="/" weight="bold" className="my-class">
+      homepage
+    </Link>
+  );
+
+  expect(screen.getByRole('link').className).toEqual('link bold my-class');
+});
+
+test('onClick is called', () => {
+  const onClick = jest.fn();
+  render(
+    <Link href="/" onClick={onClick}>
+      homepage
+    </Link>
+  );
+
+  fireEvent.click(screen.getByRole('link'));
+
+  expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test('openInNewTab adds target attribute', () => {
+  render(
+    <Link href="/" openInNewTab>
+      homepage
+    </Link>
+  );
+
+  expect(screen.getByRole('link').target).toEqual('_blank');
+});
+
+test('external adds rel attribute', () => {
+  render(
+    <Link href="/" external>
+      homepage
+    </Link>
+  );
+
+  expect(screen.getByRole('link').rel).toEqual('noopener noreferrer');
 });

--- a/packages/link/__tests__/TextLink.test.js
+++ b/packages/link/__tests__/TextLink.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import TextLink from '../lib/TextLink';
+
+test('can render text only', () => {
+  render(<TextLink text="homepage" href="/" />);
+
+  screen.getByRole('link', {name: 'homepage'});
+});
+
+test('can render icon only', () => {
+  render(<TextLink icon={<i aria-label="homepage" />} href="/" />);
+
+  screen.getByRole('link', {name: 'homepage'});
+});
+
+test('can render text and icon', () => {
+  const {container} = render(
+    <TextLink text="homepage" icon={<i aria-label="icon" />} href="/" />
+  );
+
+  screen.getByRole('link', {name: 'homepage'});
+  // Make sure icon is still rendered.
+  expect(container.getElementsByTagName('i').length).toEqual(1);
+});
+
+test('passes extra props to Link', () => {
+  render(<TextLink text="homepage" href="/" id="my-id" />);
+
+  expect(screen.getByRole('link').id).toEqual('my-id');
+});
+
+test('passes classes to Link', () => {
+  render(<TextLink text="homepage" href="/" className="my-class" />);
+
+  expect(
+    screen.getByRole('link').className.endsWith('textlink my-class')
+  ).toBeTruthy();
+});
+
+test('iconBefore renders icon before text', () => {
+  render(<TextLink text="homepage" icon={<i />} href="/" iconBefore />);
+
+  expect(screen.getByRole('link').firstChild.nodeName.toLowerCase()).toEqual(
+    'i'
+  );
+});
+
+test('!iconBefore renders text before icon', () => {
+  render(<TextLink text="homepage" icon={<i />} href="/" iconBefore={false} />);
+
+  expect(screen.getByRole('link').firstChild.nodeName.toLowerCase()).toEqual(
+    'span'
+  );
+});

--- a/packages/link/lib/Link.jsx
+++ b/packages/link/lib/Link.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import * as styles from './link.module.scss';
+import style from './link.module.scss';
 
 /**
  * A generic hyperlink component that accepts and renders any type of children.
@@ -18,7 +18,7 @@ export default function Link({
 }) {
   return (
     <a
-      className={classnames(styles.link, styles[weight], className)}
+      className={classnames(style.link, style[weight], className)}
       href={href}
       id={id}
       onClick={onClick}

--- a/packages/link/lib/TextLink.jsx
+++ b/packages/link/lib/TextLink.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Link from './Link';
-import * as styles from './text-link.module.scss';
+import style from './text-link.module.scss';
 
 /**
  * A version of the Link component that styles a hyperlink composed of
@@ -18,7 +18,7 @@ export default function TextLink({icon, iconBefore, text, ...linkProps}) {
   return (
     <Link
       {...linkProps}
-      className={classnames(styles.link, linkProps.className)}
+      className={classnames(style.link, linkProps.className)}
     >
       {iconBefore && icon}
       {text && <span key="text">{text}</span>}

--- a/packages/link/lib/TextLink.jsx
+++ b/packages/link/lib/TextLink.jsx
@@ -12,7 +12,11 @@ import style from './text-link.module.scss';
  */
 export default function TextLink({icon, iconBefore, text, ...linkProps}) {
   if (icon) {
-    icon = React.cloneElement(icon, {key: 'icon'});
+    icon = React.cloneElement(icon, {
+      // Icons should be hidden from screenreaders if text is available.
+      'aria-hidden': !!text,
+      key: 'icon',
+    });
   }
 
   return (

--- a/packages/link/lib/TextLink.jsx
+++ b/packages/link/lib/TextLink.jsx
@@ -22,7 +22,7 @@ export default function TextLink({icon, iconBefore, text, ...linkProps}) {
   return (
     <Link
       {...linkProps}
-      className={classnames(style.link, linkProps.className)}
+      className={classnames(style.textlink, linkProps.className)}
     >
       {iconBefore && icon}
       {text && <span key="text">{text}</span>}

--- a/packages/link/lib/text-link.module.scss
+++ b/packages/link/lib/text-link.module.scss
@@ -1,7 +1,7 @@
 @use '@dsco_/common/mixins';
 @use '@dsco_/common/tokens';
 
-a.link {
+a.textlink {
   display: inline-flex;
   align-items: center;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,6 @@ module.exports = {
               esModule: true,
               modules: {
                 auto: true,
-                namedExport: true,
                 localIdentName: 'dsco-[local]-[hash:base64]',
               },
             },


### PR DESCRIPTION
[DSCO-52](https://codedotorg.atlassian.net/browse/DSCO-52)

Adding unit tests for Link and TextLink. This required a couple of small code/build changes, which I'll comment on inline.

Most importantly, our unit tests also test the accessibility of our components! When asserting something about the rendered component(s), React Testing Library encourages you to use selectors that only work on accessible elements ([see this section about query priority](https://testing-library.com/docs/queries/about#priority)). For these tests, I specifically focused on only using this initial rule wherever possible:

<img width="840" alt="Screen Shot 2022-02-09 at 9 50 58 AM" src="https://user-images.githubusercontent.com/9812299/153260184-8d876f4e-2972-4b60-98c5-5e11e315935a.png">
