### PR TITLE
feat(link): prototype themes

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,6 +9,7 @@
   "exports": {
     "./mixins": "./styles/_mixins.scss",
     "./styles": "./styles/_styles.scss",
+    "./themes": "./styles/_themes.scss",
     "./tokens": "./styles/_tokens.scss"
   },
   "publishConfig": {

--- a/packages/common/styles/_styles.scss
+++ b/packages/common/styles/_styles.scss
@@ -1,9 +1,14 @@
 @import './tokens';
+@import './themes';
 @import './mixins';
 
 .dsco-text {
   @include font-regular;
-  color: $dsco-font-color;
+  @include themify {
+    background-color: themed('background-color');
+    color: themed('font-color');
+  }
+
   font-size: $dsco-font-size;
   line-height: 1.43;
 }

--- a/packages/common/styles/_themes.scss
+++ b/packages/common/styles/_themes.scss
@@ -1,0 +1,41 @@
+@import './tokens';
+
+$themes: (
+  day: (
+    background-color: transparent,
+    font-color: $dsco-charcoal,
+    link-color: $dsco-teal,
+  ),
+  night: (
+    background-color: $dsco-charcoal,
+    font-color: white,
+    link-color: aquamarine,
+  ),
+);
+
+// Source: https://medium.com/@dmitriy.borodiy/easy-color-theming-with-scss-bc38fd5734d1
+@mixin themify($themes: $themes) {
+  @each $theme, $map in $themes {
+    // Major difference here is that it generates a number of theme styles
+    // based on an attribute rather than a class like in the original article.
+    &[theme='#{$theme}'] {
+      $theme-map: () !global;
+      @each $key, $submap in $map {
+        $value: map-get(map-get($themes, $theme), '#{$key}');
+        $theme-map: map-merge(
+          $theme-map,
+          (
+            $key: $value,
+          )
+        ) !global;
+      }
+
+      @content;
+      $theme-map: null !global;
+    }
+  }
+}
+
+@function themed($key) {
+  @return map-get($theme-map, $key);
+}

--- a/packages/link/lib/Link.jsx
+++ b/packages/link/lib/Link.jsx
@@ -14,6 +14,7 @@ export default function Link({
   id,
   onClick,
   openInNewTab,
+  theme,
   weight,
 }) {
   return (
@@ -24,6 +25,7 @@ export default function Link({
       onClick={onClick}
       target={openInNewTab ? '_blank' : undefined}
       rel={external ? 'noopener noreferrer' : undefined}
+      theme={theme}
     >
       {children}
     </a>
@@ -45,6 +47,7 @@ Link.propTypes = {
   onClick: PropTypes.func,
   /** Should the link open in a new tab? */
   openInNewTab: PropTypes.bool,
+  theme: PropTypes.oneOf(['day', 'night']),
   /** Font weight of the link */
   weight: PropTypes.oneOf(['regular', 'medium', 'bold']),
 };
@@ -56,5 +59,6 @@ Link.defaultProps = {
   id: undefined,
   onClick: () => {},
   openInNewTab: false,
+  theme: 'day',
   weight: 'regular',
 };

--- a/packages/link/lib/TextLink.jsx
+++ b/packages/link/lib/TextLink.jsx
@@ -10,7 +10,13 @@ import style from './text-link.module.scss';
  *
  * Any props not defined by this component are passed through to the Link component.
  */
-export default function TextLink({icon, iconBefore, text, ...linkProps}) {
+export default function TextLink({
+  icon,
+  iconBefore,
+  text,
+  theme,
+  ...linkProps
+}) {
   if (icon) {
     icon = React.cloneElement(icon, {
       // Icons should be hidden from screenreaders if text is available.
@@ -23,6 +29,7 @@ export default function TextLink({icon, iconBefore, text, ...linkProps}) {
     <Link
       {...linkProps}
       className={classnames(style.textlink, linkProps.className)}
+      theme={theme}
     >
       {iconBefore && icon}
       {text && <span key="text">{text}</span>}
@@ -40,10 +47,12 @@ TextLink.propTypes = {
   /** Render the icon before or after the text? */
   iconBefore: PropTypes.bool,
   text: PropTypes.string,
+  theme: PropTypes.oneOf(['day', 'night']),
 };
 
 TextLink.defaultProps = {
   icon: undefined,
   iconBefore: false,
   text: undefined,
+  theme: 'day',
 };

--- a/packages/link/lib/link.module.scss
+++ b/packages/link/lib/link.module.scss
@@ -1,10 +1,13 @@
 @use '@dsco_/common/mixins';
 @use '@dsco_/common/styles';
+@use '@dsco_/common/themes';
 @use '@dsco_/common/tokens';
 
 @mixin link-text {
   @extend .dsco-text;
-  color: tokens.$dsco-link-color;
+  @include themes.themify {
+    color: themes.themed('link-color');
+  }
 }
 
 a.link {


### PR DESCRIPTION
**Demo:**

https://user-images.githubusercontent.com/9812299/153312038-7abf2861-37fe-47d8-b495-26b2e9b6f69e.mov

If we went with this solution, I think there are a couple of things we'd need for this to be production-ready:
- A provider/wrapper that automatically passes the theme from React context to each component (instead of each component manually accepting the theme prop and adding the theme attribute)
- Shared propTypes/defaultProps