### PR TITLE
fix(link): invert @supports rule for child spacing

### DIFF
--- a/packages/link/lib/text-link.module.scss
+++ b/packages/link/lib/text-link.module.scss
@@ -5,21 +5,27 @@ a.textlink {
   display: inline-flex;
   align-items: center;
 
-  // Use flexbox gap to space children. Fallback to margin if
-  // 'gap' property isn't supported:
+  // Use margin to space children. If supported, use much simpler 'gap' property.
   // https://coryrylan.com/blog/css-gap-space-with-flexbox
   $gap: tokens.$dsco-gutter;
-  gap: $gap;
-  @supports not (gap: $gap) {
-    $margin-ltr: 0 -#{$gap} 0 0;
-    $margin-rtl: 0 0 0 -#{$gap};
-    @include mixins.rtl(margin, $margin-ltr, $margin-rtl);
 
+  $margin-ltr: 0 -#{$gap} 0 0;
+  $margin-rtl: 0 0 0 -#{$gap};
+  @include mixins.rtl(margin, $margin-ltr, $margin-rtl);
+  > * {
+    $child-margin-ltr: 0 #{$gap} 0 0;
+    $child-margin-rtl: 0 0 0 #{$gap};
+    @include mixins.rtl(margin, $child-margin-ltr, $child-margin-rtl);
+  }
+
+  @supports (gap: $gap) {
+    // Undo margin rules above before applying gap.
+    margin: 0;
     > * {
-      $child-margin-ltr: 0 #{$gap} 0 0;
-      $child-margin-rtl: 0 0 0 #{$gap};
-      @include mixins.rtl(margin, $child-margin-ltr, $child-margin-rtl);
+      margin: 0;
     }
+
+    gap: $gap;
   }
 
   // Remove text-decoration from child icon on hover.


### PR DESCRIPTION
Found this issue while testing https://github.com/code-dot-org/code-dot-org/pull/44759 in a Saucelabs tunnel (which I probably should've tested before I published our packages, but alas).

Apparently, some of the browsers we test against in Saucelabs are old enough that they don't support the `@supports` rule, which resulted in this:
<img width="1395" alt="Screen Shot 2022-02-10 at 2 26 30 PM" src="https://user-images.githubusercontent.com/9812299/153507214-33c67547-2492-4961-97a3-227259400a6b.png">

It's applying `gap` even though that property isn't supported -- this should have been handled by `@supports not`, but that rule is ignored. Based on the [`@supports` browser compatibility table](https://developer.mozilla.org/en-US/docs/Web/CSS/@supports#browser_compatibility) this doesn't quite make sense to me, but is definitely the behavior I'm observing.

The solution here is to invert the approach -- instead of using `@supports not`, use `@supports` so that newer browsers will still use `gap` instead of `margin`.

Once this is merged, I'll re-publish the link package and incorporate the new version into my PR above.