### PR TITLE
fix(link): remove @supports rule for gap due to safari mixed support

### DIFF
--- a/packages/link/lib/text-link.module.scss
+++ b/packages/link/lib/text-link.module.scss
@@ -5,10 +5,10 @@ a.textlink {
   display: inline-flex;
   align-items: center;
 
-  // Use margin to space children. If supported, use much simpler 'gap' property.
-  // https://coryrylan.com/blog/css-gap-space-with-flexbox
+  // Use margin to space children. Code.org supports Safari 12, which does not support the
+  // 'gap' property with flexbox. Eventually, we can remove this margin code and replace it with
+  // `gap: $gap;`
   $gap: tokens.$dsco-gutter;
-
   $margin-ltr: 0 -#{$gap} 0 0;
   $margin-rtl: 0 0 0 -#{$gap};
   @include mixins.rtl(margin, $margin-ltr, $margin-rtl);
@@ -16,16 +16,6 @@ a.textlink {
     $child-margin-ltr: 0 #{$gap} 0 0;
     $child-margin-rtl: 0 0 0 #{$gap};
     @include mixins.rtl(margin, $child-margin-ltr, $child-margin-rtl);
-  }
-
-  @supports (gap: $gap) {
-    // Undo margin rules above before applying gap.
-    margin: 0;
-    > * {
-      margin: 0;
-    }
-
-    gap: $gap;
   }
 
   // Remove text-decoration from child icon on hover.


### PR DESCRIPTION
Follow-up to #25.

Unfortunately, my solution in that PR doesn't work for Safari because it has mixed support to the `gap` property until Safari 14.1 (`gap` with flexbox isn't supported until 14.1, but was supported earlier with CSS grid). Our Saucelabs tests run on Safari 12.

This is an issue because the mixed support meant that `@supports (gap: $gap)` was still executing in Safari, so the original UI bug returned. For now, I'll just go with the margin solution and we will wait to use `gap` until our Safari and iOS Safari versions meet the minimum versions:
https://caniuse.com/?search=gap
<img width="1437" alt="Screen Shot 2022-02-10 at 4 53 50 PM" src="https://user-images.githubusercontent.com/9812299/153521725-473762de-1bbb-41fa-bf22-47ff67ff9400.png">

Sorry for the churn here. I'm displeased to announce that I published the link package with my previous fix and will have to publish again with this fix 🤦🏻‍♀️ I've hooked everything up to Code Studio/Saucelabs locally and confirmed the bug was present in Safari before and is fixed by this change.

**Safari 12 before:**
<img width="1395" alt="Screen Shot 2022-02-10 at 5 00 34 PM" src="https://user-images.githubusercontent.com/9812299/153522242-26a824a9-5c35-43a8-8832-9ff69fe9a862.png">


**Safari 12 after:**
<img width="1395" alt="Screen Shot 2022-02-10 at 4 57 17 PM" src="https://user-images.githubusercontent.com/9812299/153522053-97604409-b6c3-4311-b75f-41aa57a5e8c9.png">