### PR TITLE
Load Gotham font-faces from CloudFront/S3

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -7,6 +7,28 @@ This package contains all DSCO design constants, tokens, and styles. These are m
 - The [`@use`](https://sass-lang.com/documentation/at-rules/use) Sass feature is only available for Dart Sass. If you are using a different Sass implementation, replace `@use` with [`@import`](https://sass-lang.com/documentation/at-rules/import). Internally, this package uses `@import` to maintain compatibility with all Sass implementations.
 - The import paths below use the "exports" field in `package.json`, which is a feature only available to Webpack 5+ consumers. If you use Webpack 4 or below, you should import this package as `@dsco_/common` (which corresponds to the "main" field in `package.json`), or point to a specific file in the package (e.g., `@dsco_/common/styles/_tokens.scss`).
 
+## [fonts](styles/_fonts.scss)
+
+Loads the Code.org Gotham font-faces from the [dsco.code.org CloudFront distribution](https://console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions/E2QIN1MOUCTV1X), which is backed by the [cdo-dsco S3 bucket](https://console.aws.amazon.com/s3/buckets/cdo-dsco). These resources are only available for code.org domains -- any third-party consumers are responsible for licensing and loading Gotham fonts independently.
+
+Example usage:
+
+### SCSS
+
+```scss
+@use '@dsco_/common/fonts';
+```
+
+### JavaScript
+
+```javascript
+import '@dsco_/common/fonts';
+```
+
+This file should not be loaded by internal packages -- it should be loaded by consumers on any pages that require these font definitions.
+
+Internally, [mixins](styles/_mixins.scss) map these font-faces to reusable font definitions. These mixins also fall back to the Code Studio font-faces, which are the same font resources but are defined slightly differently; this library defines a single 'Gotham' `font-family` with varying `font-weight`s and `font-style`s, whereas Code Studio defines each font-face as a separate `font-family` (e.g., 'Gotham 4r', 'Gotham 4i', 'Gotham 5r', etc.).
+
 ## [mixins](styles/_mixins.scss)
 
 Common mixins.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "main": "./styles/_styles.scss",
   "exports": {
+    "./fonts": "./styles/_fonts.scss",
     "./mixins": "./styles/_mixins.scss",
     "./styles": "./styles/_styles.scss",
     "./tokens": "./styles/_tokens.scss"

--- a/packages/common/styles/_fonts.scss
+++ b/packages/common/styles/_fonts.scss
@@ -1,0 +1,43 @@
+@import './tokens';
+
+@font-face {
+  font-family: $dsco-font-family-default;
+  font-weight: $dsco-font-face-regular;
+  font-style: normal;
+  src: url('https://dsco.code.org/assets/fonts/Gotham-Book.otf');
+}
+
+@font-face {
+  font-family: $dsco-font-family-default;
+  font-weight: $dsco-font-face-regular;
+  font-style: italic;
+  src: url('https://dsco.code.org/assets/fonts/Gotham-BookItalic.otf');
+}
+
+@font-face {
+  font-family: $dsco-font-family-default;
+  font-weight: $dsco-font-face-medium;
+  font-style: normal;
+  src: url('https://dsco.code.org/assets/fonts/Gotham-Medium.otf');
+}
+
+@font-face {
+  font-family: $dsco-font-family-default;
+  font-weight: $dsco-font-face-medium;
+  font-style: italic;
+  src: url('https://dsco.code.org/assets/fonts/Gotham-MediumItalic.otf');
+}
+
+@font-face {
+  font-family: $dsco-font-family-default;
+  font-weight: $dsco-font-face-bold;
+  font-style: normal;
+  src: url('https://dsco.code.org/assets/fonts/Gotham-Bold.otf');
+}
+
+@font-face {
+  font-family: $dsco-font-family-default;
+  font-weight: $dsco-font-face-bold;
+  font-style: italic;
+  src: url('https://dsco.code.org/assets/fonts/Gotham-BoldItalic.otf');
+}


### PR DESCRIPTION
[DSCO-7](https://codedotorg.atlassian.net/browse/DSCO-7)

Allows our Gotham fonts to be loaded from `@dsco_/common` by consumers. These fonts are stored in S3 and backed by a CloudFront distribution (more details in the README in this PR).

For local development, we already load our fonts into Storybook from font files in this repository. For application/consumer usage, our licensed fonts should only be available to code.org domains. However, we still want font-loading to be decoupled from our packages so that a third-party consumer could license and load Gotham fonts on their own and still be able to use `@dsco_/common` and any other packages.