### PR TITLE
Add @storybook/addon-a11y plugin

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,6 +5,7 @@ module.exports = {
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
+    '@storybook/addon-a11y',
     'storybook-addon-rtl',
   ],
   framework: '@storybook/react',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,6 +4549,196 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@storybook/addon-a11y": {
+      "version": "6.4.19",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-6.4.19.tgz",
+      "integrity": "sha512-dG6easap6W4AqyggVZPq8lBrhza8StA8J4eYz/GVdoXINSGtq/casV0rkmY3+SUXhPYux5oGavHo86j5I4Q/0Q==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "6.4.19",
+        "@storybook/api": "6.4.19",
+        "@storybook/channels": "6.4.19",
+        "@storybook/client-logger": "6.4.19",
+        "@storybook/components": "6.4.19",
+        "@storybook/core-events": "6.4.19",
+        "@storybook/csf": "0.0.2--canary.87bc651.0",
+        "@storybook/theming": "6.4.19",
+        "axe-core": "^4.2.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "react-sizeme": "^3.0.1",
+        "regenerator-runtime": "^0.13.7",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.4.19.tgz",
+          "integrity": "sha512-QNyRYhpqmHV8oJxxTBdkRlLSbDFhpBvfvMfIrIT1UXb/eemdBZTaCGVvXZ9UixoEEI7f8VwAQ44IvkU5B1509w==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "6.4.19",
+            "@storybook/channels": "6.4.19",
+            "@storybook/client-logger": "6.4.19",
+            "@storybook/core-events": "6.4.19",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/router": "6.4.19",
+            "@storybook/theming": "6.4.19",
+            "@types/webpack-env": "^1.16.0",
+            "core-js": "^3.8.2",
+            "global": "^4.4.0",
+            "regenerator-runtime": "^0.13.7"
+          }
+        },
+        "@storybook/api": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.4.19.tgz",
+          "integrity": "sha512-aDvea+NpQCBjpNp9YidO1Pr7fzzCp15FSdkG+2ihGQfv5raxrN+IIJnGUXecpe71nvlYiB+29UXBVK7AL0j51Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "6.4.19",
+            "@storybook/client-logger": "6.4.19",
+            "@storybook/core-events": "6.4.19",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/router": "6.4.19",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.4.19",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "regenerator-runtime": "^0.13.7",
+            "store2": "^2.12.0",
+            "telejson": "^5.3.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.4.19.tgz",
+          "integrity": "sha512-EwyoncFvTfmIlfsy8jTfayCxo2XchPkZk/9txipugWSmc057HdklMKPLOHWP0z5hLH0IbVIKXzdNISABm36jwQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.19.tgz",
+          "integrity": "sha512-zmg/2wyc9W3uZrvxaW4BfHcr40J0v7AGslqYXk9H+ERLVwIvrR4NhxQFaS6uITjBENyRDxwzfU3Va634WcmdDQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2",
+            "global": "^4.4.0"
+          }
+        },
+        "@storybook/components": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.4.19.tgz",
+          "integrity": "sha512-q/0V37YAJA7CNc+wSiiefeM9+3XVk8ixBNylY36QCGJgIeGQ5/79vPyUe6K4lLmsQwpmZsIq1s1Ad5+VbboeOA==",
+          "dev": true,
+          "requires": {
+            "@popperjs/core": "^2.6.0",
+            "@storybook/client-logger": "6.4.19",
+            "@storybook/csf": "0.0.2--canary.87bc651.0",
+            "@storybook/theming": "6.4.19",
+            "@types/color-convert": "^2.0.0",
+            "@types/overlayscrollbars": "^1.12.0",
+            "@types/react-syntax-highlighter": "11.0.5",
+            "color-convert": "^2.0.1",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "lodash": "^4.17.21",
+            "markdown-to-jsx": "^7.1.3",
+            "memoizerific": "^1.11.3",
+            "overlayscrollbars": "^1.13.1",
+            "polished": "^4.0.5",
+            "prop-types": "^15.7.2",
+            "react-colorful": "^5.1.2",
+            "react-popper-tooltip": "^3.1.1",
+            "react-syntax-highlighter": "^13.5.3",
+            "react-textarea-autosize": "^8.3.0",
+            "regenerator-runtime": "^0.13.7",
+            "ts-dedent": "^2.0.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.4.19.tgz",
+          "integrity": "sha512-KICzUw6XVQUJzFSCXfvhfHAuyhn4Q5J4IZEfuZkcGJS4ODkrO6tmpdYE5Cfr+so95Nfp0ErWiLUuodBsW9/rtA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.8.2"
+          }
+        },
+        "@storybook/router": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.4.19.tgz",
+          "integrity": "sha512-KWWwIzuyeEIWVezkCihwY2A76Il9tUNg0I410g9qT7NrEsKyqXGRYOijWub7c1GGyNjLqz0jtrrehtixMcJkuA==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "6.4.19",
+            "core-js": "^3.8.2",
+            "fast-deep-equal": "^3.1.3",
+            "global": "^4.4.0",
+            "history": "5.0.0",
+            "lodash": "^4.17.21",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.10.0",
+            "react-router": "^6.0.0",
+            "react-router-dom": "^6.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
+          }
+        },
+        "@storybook/theming": {
+          "version": "6.4.19",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.4.19.tgz",
+          "integrity": "sha512-V4pWmTvAxmbHR6B3jA4hPkaxZPyExHvCToy7b76DpUTpuHihijNDMAn85KhOQYIeL9q14zP/aiz899tOHsOidg==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.27",
+            "@storybook/client-logger": "6.4.19",
+            "core-js": "^3.8.2",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.27",
+            "global": "^4.4.0",
+            "memoizerific": "^1.11.3",
+            "polished": "^4.0.5",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^2.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        }
+      }
+    },
     "@storybook/addon-actions": {
       "version": "6.4.12",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-6.4.12.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.16.7",
     "@commitlint/cli": "^16.0.2",
     "@commitlint/config-conventional": "^16.0.0",
+    "@storybook/addon-a11y": "^6.4.19",
     "@storybook/addon-actions": "^6.4.12",
     "@storybook/addon-essentials": "^6.4.12",
     "@storybook/addon-links": "^6.4.12",


### PR DESCRIPTION
[DSCO-47](https://codedotorg.atlassian.net/browse/DSCO-47)

Adds the [storybook-addon-a11y plugin](https://storybook.js.org/addons/@storybook/addon-a11y/) to evaluate WCAG compliance for every story. Demo of what this looks like (it has really useful output!):


https://user-images.githubusercontent.com/9812299/155786111-6c7a5005-06be-4bcd-8859-a4a98afbbf82.mov

The same violation shows up for every component, which is that our code.org teal does not have high enough contrast on white backgrounds, which is a known issue on the design side. Eventually, we'll be adjusting our color palette for accessibility, but I don't think that will happen for some time.

